### PR TITLE
[gcc] Enable gcc-go frontend and libraries. Fixes JB#62942

### DIFF
--- a/cross-aarch64-gcc.spec
+++ b/cross-aarch64-gcc.spec
@@ -237,29 +237,6 @@ AutoReq: true
 %endif
 %global gcc_target_platform %{_target_platform}
 
-%if !%{crossbuild}
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-%global __os_install_post \
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%__os_install_post \
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%{nil}
-%endif
-%endif
-
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
 You'll need this package in order to compile C code.
@@ -1212,16 +1189,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.0.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*

--- a/cross-aarch64-gcc.spec
+++ b/cross-aarch64-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -190,6 +190,7 @@ Patch14: gcc10-pr96939-2.patch
 Patch15: gcc10-pr96939-3.patch
 Patch16: gcc10-reproducible-builds.patch
 Patch17: gcc10-reproducible-builds-buildid-for-checksum.patch
+Patch18: gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
 
 BuildRequires: binutils >= 2.31
 BuildRequires: glibc-static
@@ -221,6 +222,10 @@ Requires: binutils >= 2.25
 Requires: glibc64bit-helper
 %endif
 
+%if %{build_go}
+BuildRequires: net-tools, procps
+%endif
+
 Obsoletes: gcc < %{version}-%{release}
 AutoReq: true
 # /!crossbuild
@@ -231,6 +236,29 @@ AutoReq: true
 %global _gnu %{nil}
 %endif
 %global gcc_target_platform %{_target_platform}
+
+%if !%{crossbuild}
+%if %{build_go}
+# Avoid stripping these libraries and binaries.
+%global __os_install_post \
+chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%__os_install_post \
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%{nil}
+%endif
+%endif
 
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
@@ -474,6 +502,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -507,6 +572,7 @@ not stable, so plugins must be rebuilt any time GCC is updated.
 %patch15 -p0 -b .pr96939-3~
 %patch16 -p0 -b .reproducible-builds~
 %patch17 -p1 -b .reproducible-builds-buildid-for-checksum~
+%patch18 -p1 -b .correct-condition-for-calling-memclrHasPointers~
 
 
 echo 'Sailfish OS gcc %{version}-%{gcc_release}' > gcc/DEV-PHASE
@@ -594,6 +660,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -668,7 +740,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -806,6 +878,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -982,7 +1059,7 @@ ln -sf ../../../../%{_lib}/libobjc.so.4 libobjc.so
 ln -sf ../../../../%{_lib}/libstdc++.so.6.*[0-9] libstdc++.so
 ln -sf ../../../../%{_lib}/libgomp.so.1.* libgomp.so
 %if %{build_go}
-ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
+ln -sf ../../../libgo.so.16.* libgo.so
 %endif
 %if %{build_libquadmath}
 ln -sf ../../../../%{_lib}/libquadmath.so.0.* libquadmath.so
@@ -1003,6 +1080,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %endif
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
+%endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
 %endif
 %if %{build_libtsan}
 rm -f libtsan.so
@@ -1073,6 +1153,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1097,9 +1182,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1327,6 +1412,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1902,6 +2007,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.16*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/cross-armv7hl-gcc.spec
+++ b/cross-armv7hl-gcc.spec
@@ -237,29 +237,6 @@ AutoReq: true
 %endif
 %global gcc_target_platform %{_target_platform}
 
-%if !%{crossbuild}
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-%global __os_install_post \
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%__os_install_post \
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%{nil}
-%endif
-%endif
-
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
 You'll need this package in order to compile C code.
@@ -1212,16 +1189,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.0.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*

--- a/cross-armv7hl-gcc.spec
+++ b/cross-armv7hl-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -190,6 +190,7 @@ Patch14: gcc10-pr96939-2.patch
 Patch15: gcc10-pr96939-3.patch
 Patch16: gcc10-reproducible-builds.patch
 Patch17: gcc10-reproducible-builds-buildid-for-checksum.patch
+Patch18: gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
 
 BuildRequires: binutils >= 2.31
 BuildRequires: glibc-static
@@ -221,6 +222,10 @@ Requires: binutils >= 2.25
 Requires: glibc64bit-helper
 %endif
 
+%if %{build_go}
+BuildRequires: net-tools, procps
+%endif
+
 Obsoletes: gcc < %{version}-%{release}
 AutoReq: true
 # /!crossbuild
@@ -231,6 +236,29 @@ AutoReq: true
 %global _gnu %{nil}
 %endif
 %global gcc_target_platform %{_target_platform}
+
+%if !%{crossbuild}
+%if %{build_go}
+# Avoid stripping these libraries and binaries.
+%global __os_install_post \
+chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%__os_install_post \
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%{nil}
+%endif
+%endif
 
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
@@ -474,6 +502,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -507,6 +572,7 @@ not stable, so plugins must be rebuilt any time GCC is updated.
 %patch15 -p0 -b .pr96939-3~
 %patch16 -p0 -b .reproducible-builds~
 %patch17 -p1 -b .reproducible-builds-buildid-for-checksum~
+%patch18 -p1 -b .correct-condition-for-calling-memclrHasPointers~
 
 
 echo 'Sailfish OS gcc %{version}-%{gcc_release}' > gcc/DEV-PHASE
@@ -594,6 +660,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -668,7 +740,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -806,6 +878,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -982,7 +1059,7 @@ ln -sf ../../../../%{_lib}/libobjc.so.4 libobjc.so
 ln -sf ../../../../%{_lib}/libstdc++.so.6.*[0-9] libstdc++.so
 ln -sf ../../../../%{_lib}/libgomp.so.1.* libgomp.so
 %if %{build_go}
-ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
+ln -sf ../../../libgo.so.16.* libgo.so
 %endif
 %if %{build_libquadmath}
 ln -sf ../../../../%{_lib}/libquadmath.so.0.* libquadmath.so
@@ -1003,6 +1080,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %endif
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
+%endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
 %endif
 %if %{build_libtsan}
 rm -f libtsan.so
@@ -1073,6 +1153,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1097,9 +1182,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1327,6 +1412,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1902,6 +2007,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.16*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/cross-i486-gcc.spec
+++ b/cross-i486-gcc.spec
@@ -237,29 +237,6 @@ AutoReq: true
 %endif
 %global gcc_target_platform %{_target_platform}
 
-%if !%{crossbuild}
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-%global __os_install_post \
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%__os_install_post \
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%{nil}
-%endif
-%endif
-
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
 You'll need this package in order to compile C code.
@@ -1212,16 +1189,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.0.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*

--- a/cross-i486-gcc.spec
+++ b/cross-i486-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -190,6 +190,7 @@ Patch14: gcc10-pr96939-2.patch
 Patch15: gcc10-pr96939-3.patch
 Patch16: gcc10-reproducible-builds.patch
 Patch17: gcc10-reproducible-builds-buildid-for-checksum.patch
+Patch18: gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
 
 BuildRequires: binutils >= 2.31
 BuildRequires: glibc-static
@@ -221,6 +222,10 @@ Requires: binutils >= 2.25
 Requires: glibc64bit-helper
 %endif
 
+%if %{build_go}
+BuildRequires: net-tools, procps
+%endif
+
 Obsoletes: gcc < %{version}-%{release}
 AutoReq: true
 # /!crossbuild
@@ -231,6 +236,29 @@ AutoReq: true
 %global _gnu %{nil}
 %endif
 %global gcc_target_platform %{_target_platform}
+
+%if !%{crossbuild}
+%if %{build_go}
+# Avoid stripping these libraries and binaries.
+%global __os_install_post \
+chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%__os_install_post \
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%{nil}
+%endif
+%endif
 
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
@@ -474,6 +502,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -507,6 +572,7 @@ not stable, so plugins must be rebuilt any time GCC is updated.
 %patch15 -p0 -b .pr96939-3~
 %patch16 -p0 -b .reproducible-builds~
 %patch17 -p1 -b .reproducible-builds-buildid-for-checksum~
+%patch18 -p1 -b .correct-condition-for-calling-memclrHasPointers~
 
 
 echo 'Sailfish OS gcc %{version}-%{gcc_release}' > gcc/DEV-PHASE
@@ -594,6 +660,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -668,7 +740,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -806,6 +878,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -982,7 +1059,7 @@ ln -sf ../../../../%{_lib}/libobjc.so.4 libobjc.so
 ln -sf ../../../../%{_lib}/libstdc++.so.6.*[0-9] libstdc++.so
 ln -sf ../../../../%{_lib}/libgomp.so.1.* libgomp.so
 %if %{build_go}
-ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
+ln -sf ../../../libgo.so.16.* libgo.so
 %endif
 %if %{build_libquadmath}
 ln -sf ../../../../%{_lib}/libquadmath.so.0.* libquadmath.so
@@ -1003,6 +1080,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %endif
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
+%endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
 %endif
 %if %{build_libtsan}
 rm -f libtsan.so
@@ -1073,6 +1153,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1097,9 +1182,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1327,6 +1412,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1902,6 +2007,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.16*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/cross-x86_64-gcc.spec
+++ b/cross-x86_64-gcc.spec
@@ -237,29 +237,6 @@ AutoReq: true
 %endif
 %global gcc_target_platform %{_target_platform}
 
-%if !%{crossbuild}
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-%global __os_install_post \
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%__os_install_post \
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%{nil}
-%endif
-%endif
-
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
 You'll need this package in order to compile C code.
@@ -1212,16 +1189,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.0.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*

--- a/cross-x86_64-gcc.spec
+++ b/cross-x86_64-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -190,6 +190,7 @@ Patch14: gcc10-pr96939-2.patch
 Patch15: gcc10-pr96939-3.patch
 Patch16: gcc10-reproducible-builds.patch
 Patch17: gcc10-reproducible-builds-buildid-for-checksum.patch
+Patch18: gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
 
 BuildRequires: binutils >= 2.31
 BuildRequires: glibc-static
@@ -221,6 +222,10 @@ Requires: binutils >= 2.25
 Requires: glibc64bit-helper
 %endif
 
+%if %{build_go}
+BuildRequires: net-tools, procps
+%endif
+
 Obsoletes: gcc < %{version}-%{release}
 AutoReq: true
 # /!crossbuild
@@ -231,6 +236,29 @@ AutoReq: true
 %global _gnu %{nil}
 %endif
 %global gcc_target_platform %{_target_platform}
+
+%if !%{crossbuild}
+%if %{build_go}
+# Avoid stripping these libraries and binaries.
+%global __os_install_post \
+chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%__os_install_post \
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
+chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
+chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
+chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
+%{nil}
+%endif
+%endif
 
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
@@ -474,6 +502,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -507,6 +572,7 @@ not stable, so plugins must be rebuilt any time GCC is updated.
 %patch15 -p0 -b .pr96939-3~
 %patch16 -p0 -b .reproducible-builds~
 %patch17 -p1 -b .reproducible-builds-buildid-for-checksum~
+%patch18 -p1 -b .correct-condition-for-calling-memclrHasPointers~
 
 
 echo 'Sailfish OS gcc %{version}-%{gcc_release}' > gcc/DEV-PHASE
@@ -594,6 +660,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -668,7 +740,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -806,6 +878,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -982,7 +1059,7 @@ ln -sf ../../../../%{_lib}/libobjc.so.4 libobjc.so
 ln -sf ../../../../%{_lib}/libstdc++.so.6.*[0-9] libstdc++.so
 ln -sf ../../../../%{_lib}/libgomp.so.1.* libgomp.so
 %if %{build_go}
-ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
+ln -sf ../../../libgo.so.16.* libgo.so
 %endif
 %if %{build_libquadmath}
 ln -sf ../../../../%{_lib}/libquadmath.so.0.* libquadmath.so
@@ -1003,6 +1080,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %endif
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
+%endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.16.* libgo.so
 %endif
 %if %{build_libtsan}
 rm -f libtsan.so
@@ -1073,6 +1153,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1097,9 +1182,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1327,6 +1412,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1902,6 +2007,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.16*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/gcc.spec
+++ b/gcc.spec
@@ -236,29 +236,6 @@ AutoReq: true
 %endif
 %global gcc_target_platform %{_target_platform}
 
-%if !%{crossbuild}
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-%global __os_install_post \
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%__os_install_post \
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.* \
-chmod 755 %{buildroot}%{_prefix}/bin/go.gcc \
-chmod 755 %{buildroot}%{_prefix}/bin/gofmt.gcc \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json \
-chmod 755 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet \
-%{nil}
-%endif
-%endif
-
 %description
 The gcc package contains the GNU Compiler Collection version 4.9.
 You'll need this package in order to compile C code.
@@ -1211,16 +1188,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.0.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.16.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*

--- a/gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
+++ b/gcc10-compiler-correct-condition-for-calling-memclrHasPoin.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Lance Taylor <iant@golang.org>
+Date: Sat, 21 Aug 2021 12:42:19 -0700
+Subject: [PATCH] compiler: correct condition for calling memclrHasPointers
+
+When compiling append(s, make([]typ, ln)...), where typ has a pointer,
+and the append fits within the existing capacity of s, the condition
+used to clear out the new elements was reversed.
+
+Fixes golang/go#47771
+
+Reviewed-on: https://go-review.googlesource.com/c/gofrontend/+/344189
+
+---
+ gcc/go/gofrontend/MERGE          | 2 +-
+ gcc/go/gofrontend/expressions.cc | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/go/gofrontend/MERGE b/gcc/go/gofrontend/MERGE
+index e425f15..ff41af7 100644
+--- a/gcc/go/gofrontend/MERGE
++++ b/gcc/go/gofrontend/MERGE
+@@ -1,4 +1,4 @@
+-823c91088bc6ac606362fc34b2880ce0de1624ad
++21b30eddc59d92a07264c3b21eb032d6c303d16f
+ 
+ The first line of this file holds the git revision number of the last
+ merge done from the gofrontend repository.
+diff --git a/gcc/go/gofrontend/expressions.cc b/gcc/go/gofrontend/expressions.cc
+index 8f59b18..f27375d 100644
+--- a/gcc/go/gofrontend/expressions.cc
++++ b/gcc/go/gofrontend/expressions.cc
+@@ -9075,7 +9075,7 @@ Builtin_call_expression::flatten_append(Gogo* gogo, Named_object* function,
+               ref2 = Expression::make_cast(uint_type, ref2, loc);
+               cond = Expression::make_binary(OPERATOR_GT, ref, ref2, loc);
+               zero = Expression::make_integer_ul(0, int_type, loc);
+-              call = Expression::make_conditional(cond, call, zero, loc);
++              call = Expression::make_conditional(cond, zero, call, loc);
+             }
+         }
+       else


### PR DESCRIPTION
Note: GCC 10

First steps towards building the Go compiler. In GCC 10, `gccgo` fully implements [Go 1.12.2](https://go.dev/doc/install/gccgo).  If needed later on, this also provides a path to build some older first-party Go compiler which can then build itself.

- Restore missing pieces in .spec file
- Enable `gcc-go` with `build_go 1`

This branch compiles, installs and builds a simple hello-world Go application. Tested in Platform SDK (i486) and on Xperia 10 III (aarch64).