### PR TITLE
[gcc] Enable gcc-go frontend and libraries. Fixes JB#62943

### DIFF
--- a/rpm/cross-aarch64-gcc.spec
+++ b/rpm/cross-aarch64-gcc.spec
@@ -1395,26 +1395,6 @@ if posix.access ("/sbin/ldconfig", "x") then
   end
 end
 
-%post go
-pushd %{_bindir}
-if [ ! -f go ] ; then
-  ln -s go.gcc go
-fi
-if [ ! -f gofmt ] ; then
-  ln -s gofmt.gcc gofmt
-fi
-popd
-
-%preun go
-pushd %{_bindir}
-if [ -L go ]; then
-  rm go
-fi
-if [ -L gofmt ]; then
-  rm gofmt
-fi
-popd
-
 %post -n libstdc++ -p /sbin/ldconfig
 
 %postun -n libstdc++ -p /sbin/ldconfig
@@ -2021,10 +2001,8 @@ popd
 
 %if %{build_go}
 %files go
-%ghost %{_prefix}/bin/go
 %attr(755,root,root) %{_prefix}/bin/go.gcc
 %{_prefix}/bin/gccgo
-%ghost %{_prefix}/bin/gofmt
 %attr(755,root,root) %{_prefix}/bin/gofmt.gcc
 %{_mandir}/man1/gccgo.1*
 %{_mandir}/man1/go.1*

--- a/rpm/cross-aarch64-gcc.spec
+++ b/rpm/cross-aarch64-gcc.spec
@@ -109,7 +109,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -222,6 +222,10 @@ Requires: binutils >= 2.25
 
 %if %{build_64bit_multilib}
 Requires: glibc64bit-helper
+%endif
+
+%if %{build_go}
+BuildRequires: net-tools, procps
 %endif
 
 Obsoletes: gcc < %{version}-%{release}
@@ -479,6 +483,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -603,6 +644,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -678,7 +725,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -731,6 +778,11 @@ make doc-html-doxygen
 make doc-man-doxygen
 cd ../..
 %endif
+
+# Clean any old compressed docs
+if [ -d rpm.doc ]; then
+  find rpm.doc -name "*.bz2" -delete
+fi
 
 # Copy various doc files here and there
 cd ..
@@ -816,6 +868,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -1014,6 +1071,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
 %endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.22.* libgo.so
+%endif
 %if %{build_libtsan}
 rm -f libtsan.so
 echo 'INPUT ( %{_prefix}/%{_lib}/'`echo ../../../../%{_lib}/libtsan.so.2.* | sed 's,^.*libt,libt,'`' )' > libtsan.so
@@ -1085,6 +1145,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1110,9 +1175,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1140,16 +1205,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.2.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.22.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*
@@ -1339,6 +1394,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1942,6 +2017,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.22*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/rpm/cross-aarch64-gcc.spec
+++ b/rpm/cross-aarch64-gcc.spec
@@ -246,14 +246,15 @@ Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man and info pages for %{name}.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgcc
 Summary: GCC version 13.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc
@@ -313,7 +314,8 @@ Autoreq: true
 %description -n libstdc++-doc
 Manual, doxygen generated API information and Frequently Asked Questions
 for the GNU standard C++ library.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgomp
 Summary: GCC OpenMP v4.5 shared support library
@@ -1279,7 +1281,8 @@ set +x
 #install -m0644 -t %{buildroot}%{_docdir}/libquadmath-%{version} \
 #        rpm.doc/libquadmath/ChangeLog*
 #%endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %if !%{crossbuild}
 # checking and split packaging for native ...
@@ -1386,11 +1389,11 @@ end
 %{_prefix}/bin/gcc-nm
 %{_prefix}/bin/gcc-ranlib
 %{_prefix}/bin/lto-dump
-#%ifnarch %{arm} aarch64 mipsel
-#%{_prefix}/bin/%{gcc_target_platform}-gcc
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ar
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-nm
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ranlib
+#%ifnarch %%{arm} aarch64 mipsel
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ar
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-nm
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ranlib
 #%endif
 %dir %{_prefix}/%{_lib}/gcc
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
@@ -1401,8 +1404,8 @@ end
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/*
-#%if !%{crossbuild}
+#%%{_prefix}/libexec/gcc/%%{gcc_target_platform}/%%{gcc_version}/*
+#%if !%%{crossbuild}
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto1
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto-wrapper
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/liblto_plugin.so*
@@ -1415,7 +1418,7 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/plugin/include/*
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/*
+#%%{_prefix}/%%{_lib}/gcc/%%{gcc_target_platform}/%%{gcc_version}/include/*
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/rpmver
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stddef.h
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stdarg.h
@@ -1709,7 +1712,8 @@ end
 %{_mandir}/man1/g++.1*
 %{_mandir}/man1/lto-dump.1*
 %{_mandir}/man7/*
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n cpp -f cpplib.lang
 %defattr(-,root,root,-)
@@ -1799,7 +1803,8 @@ end
 %{_mandir}/man3/*
 %{_docdir}/libstdc++-%{version}
 %endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n libgomp
 %defattr(-,root,root,-)

--- a/rpm/cross-aarch64-gcc.spec
+++ b/rpm/cross-aarch64-gcc.spec
@@ -1120,8 +1120,8 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libquadmath.so.0.*
 %endif
 %if %{build_d}
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.1.*
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.1.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.4.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.4.*
 %endif
 %if %{build_libitm}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libitm.so.1.*

--- a/rpm/cross-armv7hl-gcc.spec
+++ b/rpm/cross-armv7hl-gcc.spec
@@ -1395,26 +1395,6 @@ if posix.access ("/sbin/ldconfig", "x") then
   end
 end
 
-%post go
-pushd %{_bindir}
-if [ ! -f go ] ; then
-  ln -s go.gcc go
-fi
-if [ ! -f gofmt ] ; then
-  ln -s gofmt.gcc gofmt
-fi
-popd
-
-%preun go
-pushd %{_bindir}
-if [ -L go ]; then
-  rm go
-fi
-if [ -L gofmt ]; then
-  rm gofmt
-fi
-popd
-
 %post -n libstdc++ -p /sbin/ldconfig
 
 %postun -n libstdc++ -p /sbin/ldconfig
@@ -2021,10 +2001,8 @@ popd
 
 %if %{build_go}
 %files go
-%ghost %{_prefix}/bin/go
 %attr(755,root,root) %{_prefix}/bin/go.gcc
 %{_prefix}/bin/gccgo
-%ghost %{_prefix}/bin/gofmt
 %attr(755,root,root) %{_prefix}/bin/gofmt.gcc
 %{_mandir}/man1/gccgo.1*
 %{_mandir}/man1/go.1*

--- a/rpm/cross-armv7hl-gcc.spec
+++ b/rpm/cross-armv7hl-gcc.spec
@@ -109,7 +109,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -222,6 +222,10 @@ Requires: binutils >= 2.25
 
 %if %{build_64bit_multilib}
 Requires: glibc64bit-helper
+%endif
+
+%if %{build_go}
+BuildRequires: net-tools, procps
 %endif
 
 Obsoletes: gcc < %{version}-%{release}
@@ -479,6 +483,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -603,6 +644,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -678,7 +725,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -731,6 +778,11 @@ make doc-html-doxygen
 make doc-man-doxygen
 cd ../..
 %endif
+
+# Clean any old compressed docs
+if [ -d rpm.doc ]; then
+  find rpm.doc -name "*.bz2" -delete
+fi
 
 # Copy various doc files here and there
 cd ..
@@ -816,6 +868,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -1014,6 +1071,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
 %endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.22.* libgo.so
+%endif
 %if %{build_libtsan}
 rm -f libtsan.so
 echo 'INPUT ( %{_prefix}/%{_lib}/'`echo ../../../../%{_lib}/libtsan.so.2.* | sed 's,^.*libt,libt,'`' )' > libtsan.so
@@ -1085,6 +1145,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1110,9 +1175,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1140,16 +1205,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.2.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.22.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*
@@ -1339,6 +1394,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1942,6 +2017,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.22*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/rpm/cross-armv7hl-gcc.spec
+++ b/rpm/cross-armv7hl-gcc.spec
@@ -246,14 +246,15 @@ Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man and info pages for %{name}.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgcc
 Summary: GCC version 13.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc
@@ -313,7 +314,8 @@ Autoreq: true
 %description -n libstdc++-doc
 Manual, doxygen generated API information and Frequently Asked Questions
 for the GNU standard C++ library.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgomp
 Summary: GCC OpenMP v4.5 shared support library
@@ -1279,7 +1281,8 @@ set +x
 #install -m0644 -t %{buildroot}%{_docdir}/libquadmath-%{version} \
 #        rpm.doc/libquadmath/ChangeLog*
 #%endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %if !%{crossbuild}
 # checking and split packaging for native ...
@@ -1386,11 +1389,11 @@ end
 %{_prefix}/bin/gcc-nm
 %{_prefix}/bin/gcc-ranlib
 %{_prefix}/bin/lto-dump
-#%ifnarch %{arm} aarch64 mipsel
-#%{_prefix}/bin/%{gcc_target_platform}-gcc
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ar
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-nm
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ranlib
+#%ifnarch %%{arm} aarch64 mipsel
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ar
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-nm
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ranlib
 #%endif
 %dir %{_prefix}/%{_lib}/gcc
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
@@ -1401,8 +1404,8 @@ end
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/*
-#%if !%{crossbuild}
+#%%{_prefix}/libexec/gcc/%%{gcc_target_platform}/%%{gcc_version}/*
+#%if !%%{crossbuild}
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto1
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto-wrapper
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/liblto_plugin.so*
@@ -1415,7 +1418,7 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/plugin/include/*
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/*
+#%%{_prefix}/%%{_lib}/gcc/%%{gcc_target_platform}/%%{gcc_version}/include/*
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/rpmver
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stddef.h
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stdarg.h
@@ -1709,7 +1712,8 @@ end
 %{_mandir}/man1/g++.1*
 %{_mandir}/man1/lto-dump.1*
 %{_mandir}/man7/*
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n cpp -f cpplib.lang
 %defattr(-,root,root,-)
@@ -1799,7 +1803,8 @@ end
 %{_mandir}/man3/*
 %{_docdir}/libstdc++-%{version}
 %endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n libgomp
 %defattr(-,root,root,-)

--- a/rpm/cross-armv7hl-gcc.spec
+++ b/rpm/cross-armv7hl-gcc.spec
@@ -1120,8 +1120,8 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libquadmath.so.0.*
 %endif
 %if %{build_d}
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.1.*
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.1.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.4.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.4.*
 %endif
 %if %{build_libitm}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libitm.so.1.*

--- a/rpm/cross-i486-gcc.spec
+++ b/rpm/cross-i486-gcc.spec
@@ -1395,26 +1395,6 @@ if posix.access ("/sbin/ldconfig", "x") then
   end
 end
 
-%post go
-pushd %{_bindir}
-if [ ! -f go ] ; then
-  ln -s go.gcc go
-fi
-if [ ! -f gofmt ] ; then
-  ln -s gofmt.gcc gofmt
-fi
-popd
-
-%preun go
-pushd %{_bindir}
-if [ -L go ]; then
-  rm go
-fi
-if [ -L gofmt ]; then
-  rm gofmt
-fi
-popd
-
 %post -n libstdc++ -p /sbin/ldconfig
 
 %postun -n libstdc++ -p /sbin/ldconfig
@@ -2021,10 +2001,8 @@ popd
 
 %if %{build_go}
 %files go
-%ghost %{_prefix}/bin/go
 %attr(755,root,root) %{_prefix}/bin/go.gcc
 %{_prefix}/bin/gccgo
-%ghost %{_prefix}/bin/gofmt
 %attr(755,root,root) %{_prefix}/bin/gofmt.gcc
 %{_mandir}/man1/gccgo.1*
 %{_mandir}/man1/go.1*

--- a/rpm/cross-i486-gcc.spec
+++ b/rpm/cross-i486-gcc.spec
@@ -109,7 +109,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -222,6 +222,10 @@ Requires: binutils >= 2.25
 
 %if %{build_64bit_multilib}
 Requires: glibc64bit-helper
+%endif
+
+%if %{build_go}
+BuildRequires: net-tools, procps
 %endif
 
 Obsoletes: gcc < %{version}-%{release}
@@ -479,6 +483,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -603,6 +644,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -678,7 +725,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -731,6 +778,11 @@ make doc-html-doxygen
 make doc-man-doxygen
 cd ../..
 %endif
+
+# Clean any old compressed docs
+if [ -d rpm.doc ]; then
+  find rpm.doc -name "*.bz2" -delete
+fi
 
 # Copy various doc files here and there
 cd ..
@@ -816,6 +868,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -1014,6 +1071,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
 %endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.22.* libgo.so
+%endif
 %if %{build_libtsan}
 rm -f libtsan.so
 echo 'INPUT ( %{_prefix}/%{_lib}/'`echo ../../../../%{_lib}/libtsan.so.2.* | sed 's,^.*libt,libt,'`' )' > libtsan.so
@@ -1085,6 +1145,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1110,9 +1175,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1140,16 +1205,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.2.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.22.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*
@@ -1339,6 +1394,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1942,6 +2017,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.22*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/rpm/cross-i486-gcc.spec
+++ b/rpm/cross-i486-gcc.spec
@@ -246,14 +246,15 @@ Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man and info pages for %{name}.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgcc
 Summary: GCC version 13.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc
@@ -313,7 +314,8 @@ Autoreq: true
 %description -n libstdc++-doc
 Manual, doxygen generated API information and Frequently Asked Questions
 for the GNU standard C++ library.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgomp
 Summary: GCC OpenMP v4.5 shared support library
@@ -1279,7 +1281,8 @@ set +x
 #install -m0644 -t %{buildroot}%{_docdir}/libquadmath-%{version} \
 #        rpm.doc/libquadmath/ChangeLog*
 #%endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %if !%{crossbuild}
 # checking and split packaging for native ...
@@ -1386,11 +1389,11 @@ end
 %{_prefix}/bin/gcc-nm
 %{_prefix}/bin/gcc-ranlib
 %{_prefix}/bin/lto-dump
-#%ifnarch %{arm} aarch64 mipsel
-#%{_prefix}/bin/%{gcc_target_platform}-gcc
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ar
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-nm
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ranlib
+#%ifnarch %%{arm} aarch64 mipsel
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ar
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-nm
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ranlib
 #%endif
 %dir %{_prefix}/%{_lib}/gcc
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
@@ -1401,8 +1404,8 @@ end
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/*
-#%if !%{crossbuild}
+#%%{_prefix}/libexec/gcc/%%{gcc_target_platform}/%%{gcc_version}/*
+#%if !%%{crossbuild}
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto1
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto-wrapper
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/liblto_plugin.so*
@@ -1415,7 +1418,7 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/plugin/include/*
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/*
+#%%{_prefix}/%%{_lib}/gcc/%%{gcc_target_platform}/%%{gcc_version}/include/*
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/rpmver
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stddef.h
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stdarg.h
@@ -1709,7 +1712,8 @@ end
 %{_mandir}/man1/g++.1*
 %{_mandir}/man1/lto-dump.1*
 %{_mandir}/man7/*
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n cpp -f cpplib.lang
 %defattr(-,root,root,-)
@@ -1799,7 +1803,8 @@ end
 %{_mandir}/man3/*
 %{_docdir}/libstdc++-%{version}
 %endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n libgomp
 %defattr(-,root,root,-)

--- a/rpm/cross-i486-gcc.spec
+++ b/rpm/cross-i486-gcc.spec
@@ -1120,8 +1120,8 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libquadmath.so.0.*
 %endif
 %if %{build_d}
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.1.*
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.1.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.4.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.4.*
 %endif
 %if %{build_libitm}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libitm.so.1.*

--- a/rpm/cross-x86_64-gcc.spec
+++ b/rpm/cross-x86_64-gcc.spec
@@ -1395,26 +1395,6 @@ if posix.access ("/sbin/ldconfig", "x") then
   end
 end
 
-%post go
-pushd %{_bindir}
-if [ ! -f go ] ; then
-  ln -s go.gcc go
-fi
-if [ ! -f gofmt ] ; then
-  ln -s gofmt.gcc gofmt
-fi
-popd
-
-%preun go
-pushd %{_bindir}
-if [ -L go ]; then
-  rm go
-fi
-if [ -L gofmt ]; then
-  rm gofmt
-fi
-popd
-
 %post -n libstdc++ -p /sbin/ldconfig
 
 %postun -n libstdc++ -p /sbin/ldconfig
@@ -2021,10 +2001,8 @@ popd
 
 %if %{build_go}
 %files go
-%ghost %{_prefix}/bin/go
 %attr(755,root,root) %{_prefix}/bin/go.gcc
 %{_prefix}/bin/gccgo
-%ghost %{_prefix}/bin/gofmt
 %attr(755,root,root) %{_prefix}/bin/gofmt.gcc
 %{_mandir}/man1/gccgo.1*
 %{_mandir}/man1/go.1*

--- a/rpm/cross-x86_64-gcc.spec
+++ b/rpm/cross-x86_64-gcc.spec
@@ -109,7 +109,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -222,6 +222,10 @@ Requires: binutils >= 2.25
 
 %if %{build_64bit_multilib}
 Requires: glibc64bit-helper
+%endif
+
+%if %{build_go}
+BuildRequires: net-tools, procps
 %endif
 
 Obsoletes: gcc < %{version}-%{release}
@@ -479,6 +483,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -603,6 +644,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -678,7 +725,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -731,6 +778,11 @@ make doc-html-doxygen
 make doc-man-doxygen
 cd ../..
 %endif
+
+# Clean any old compressed docs
+if [ -d rpm.doc ]; then
+  find rpm.doc -name "*.bz2" -delete
+fi
 
 # Copy various doc files here and there
 cd ..
@@ -816,6 +868,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -1014,6 +1071,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
 %endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.22.* libgo.so
+%endif
 %if %{build_libtsan}
 rm -f libtsan.so
 echo 'INPUT ( %{_prefix}/%{_lib}/'`echo ../../../../%{_lib}/libtsan.so.2.* | sed 's,^.*libt,libt,'`' )' > libtsan.so
@@ -1085,6 +1145,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1110,9 +1175,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1140,16 +1205,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.2.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.22.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*
@@ -1339,6 +1394,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1942,6 +2017,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.22*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/rpm/cross-x86_64-gcc.spec
+++ b/rpm/cross-x86_64-gcc.spec
@@ -246,14 +246,15 @@ Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man and info pages for %{name}.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgcc
 Summary: GCC version 13.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc
@@ -313,7 +314,8 @@ Autoreq: true
 %description -n libstdc++-doc
 Manual, doxygen generated API information and Frequently Asked Questions
 for the GNU standard C++ library.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgomp
 Summary: GCC OpenMP v4.5 shared support library
@@ -1279,7 +1281,8 @@ set +x
 #install -m0644 -t %{buildroot}%{_docdir}/libquadmath-%{version} \
 #        rpm.doc/libquadmath/ChangeLog*
 #%endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %if !%{crossbuild}
 # checking and split packaging for native ...
@@ -1386,11 +1389,11 @@ end
 %{_prefix}/bin/gcc-nm
 %{_prefix}/bin/gcc-ranlib
 %{_prefix}/bin/lto-dump
-#%ifnarch %{arm} aarch64 mipsel
-#%{_prefix}/bin/%{gcc_target_platform}-gcc
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ar
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-nm
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ranlib
+#%ifnarch %%{arm} aarch64 mipsel
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ar
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-nm
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ranlib
 #%endif
 %dir %{_prefix}/%{_lib}/gcc
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
@@ -1401,8 +1404,8 @@ end
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/*
-#%if !%{crossbuild}
+#%%{_prefix}/libexec/gcc/%%{gcc_target_platform}/%%{gcc_version}/*
+#%if !%%{crossbuild}
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto1
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto-wrapper
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/liblto_plugin.so*
@@ -1415,7 +1418,7 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/plugin/include/*
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/*
+#%%{_prefix}/%%{_lib}/gcc/%%{gcc_target_platform}/%%{gcc_version}/include/*
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/rpmver
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stddef.h
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stdarg.h
@@ -1709,7 +1712,8 @@ end
 %{_mandir}/man1/g++.1*
 %{_mandir}/man1/lto-dump.1*
 %{_mandir}/man7/*
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n cpp -f cpplib.lang
 %defattr(-,root,root,-)
@@ -1799,7 +1803,8 @@ end
 %{_mandir}/man3/*
 %{_docdir}/libstdc++-%{version}
 %endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n libgomp
 %defattr(-,root,root,-)

--- a/rpm/cross-x86_64-gcc.spec
+++ b/rpm/cross-x86_64-gcc.spec
@@ -1120,8 +1120,8 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libquadmath.so.0.*
 %endif
 %if %{build_d}
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.1.*
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.1.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.4.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.4.*
 %endif
 %if %{build_libitm}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libitm.so.1.*

--- a/rpm/gcc.spec
+++ b/rpm/gcc.spec
@@ -1394,26 +1394,6 @@ if posix.access ("/sbin/ldconfig", "x") then
   end
 end
 
-%post go
-pushd %{_bindir}
-if [ ! -f go ] ; then
-  ln -s go.gcc go
-fi
-if [ ! -f gofmt ] ; then
-  ln -s gofmt.gcc gofmt
-fi
-popd
-
-%preun go
-pushd %{_bindir}
-if [ -L go ]; then
-  rm go
-fi
-if [ -L gofmt ]; then
-  rm gofmt
-fi
-popd
-
 %post -n libstdc++ -p /sbin/ldconfig
 
 %postun -n libstdc++ -p /sbin/ldconfig
@@ -2020,10 +2000,8 @@ popd
 
 %if %{build_go}
 %files go
-%ghost %{_prefix}/bin/go
 %attr(755,root,root) %{_prefix}/bin/go.gcc
 %{_prefix}/bin/gccgo
-%ghost %{_prefix}/bin/gofmt
 %attr(755,root,root) %{_prefix}/bin/gofmt.gcc
 %{_mandir}/man1/gccgo.1*
 %{_mandir}/man1/go.1*

--- a/rpm/gcc.spec
+++ b/rpm/gcc.spec
@@ -108,7 +108,7 @@ ExclusiveArch: %ix86 x86_64
 %global _performance_build 1
 %global build_ada 0
 %global build_objc 0
-%global build_go 0
+%global build_go 1
 %global build_d 0
 %global include_gappletviewer 0
 %global build_libstdcxx_doc 0
@@ -221,6 +221,10 @@ Requires: binutils >= 2.25
 
 %if %{build_64bit_multilib}
 Requires: glibc64bit-helper
+%endif
+
+%if %{build_go}
+BuildRequires: net-tools, procps
 %endif
 
 Obsoletes: gcc < %{version}-%{release}
@@ -478,6 +482,43 @@ Autoreq: true
 This is one set of libraries which support 64bit multilib on top of
 32bit enviroment from compiler side.
 
+%package go
+Summary: Go support
+Requires: gcc = %{version}-%{release}
+Requires: libgo = %{version}-%{release}
+Requires: libgo-devel = %{version}-%{release}
+Provides: gccgo = %{version}-%{release}
+Autoreq: true
+
+%description go
+The gcc-go package provides support for compiling Go programs
+with the GNU Compiler Collection.
+
+%package -n libgo
+Summary: Go runtime
+Autoreq: true
+
+%description -n libgo
+This package contains Go shared library which is needed to run
+Go dynamically linked programs.
+
+%package -n libgo-devel
+Summary: Go development libraries
+Requires: libgo = %{version}-%{release}
+Autoreq: true
+
+%description -n libgo-devel
+This package includes libraries and support files for compiling
+Go programs.
+
+%package -n libgo-static
+Summary: Static Go libraries
+Requires: libgo = %{version}-%{release}
+Requires: gcc = %{version}-%{release}
+
+%description -n libgo-static
+This package contains static Go libraries.
+
 %package plugin-devel
 Summary: Support for compiling GCC plugins
 Requires: gcc = %{version}-%{release}
@@ -602,6 +643,12 @@ esac
 #export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-O2/-O2 -fkeep-inline-functions/g"`
 export OPT_FLAGS=`echo "$OPT_FLAGS" | sed -e "s/-fstack-protector//g"`
 
+%if %{build_go}
+enablelgo=,go
+%else
+enablelgo=
+%endif
+
 %if %{crossbuild}
 # cross build
 export PATH=/opt/cross/bin:$PATH
@@ -677,7 +724,7 @@ CC="$CC" CFLAGS="$OPT_FLAGS" CXXFLAGS="`echo $OPT_FLAGS | sed 's/ -Wall / /g'`" 
 	--enable-linker-build-id \
 	--disable-libmpx \
 %if %{bootstrap} == 0
-	--enable-languages=c,c++,lto \
+	--enable-languages=c,c++${enablelgo},lto \
 	--enable-threads=posix \
 	--enable-shared \
 %endif
@@ -730,6 +777,11 @@ make doc-html-doxygen
 make doc-man-doxygen
 cd ../..
 %endif
+
+# Clean any old compressed docs
+if [ -d rpm.doc ]; then
+  find rpm.doc -name "*.bz2" -delete
+fi
 
 # Copy various doc files here and there
 cd ..
@@ -815,6 +867,11 @@ mkdir -p $FULLEPATH
 ln -sf gcc %{buildroot}%{_prefix}/bin/cc
 mkdir -p %{buildroot}/%{_lib}
 ln -sf ..%{_prefix}/bin/cpp %{buildroot}/%{_lib}/cpp
+
+%if %{build_go}
+mv %{buildroot}%{_prefix}/bin/go{,.gcc}
+mv %{buildroot}%{_prefix}/bin/gofmt{,.gcc}
+%endif
 
 cxxconfig="`find %{gcc_target_platform}/libstdc++-v3/include -name c++config.h`"
 for i in `find %{gcc_target_platform}/[36]*/libstdc++-v3/include -name c++config.h 2>/dev/null`; do
@@ -1013,6 +1070,9 @@ mv ../../../../%{_lib}/libasan_preinit.o libasan_preinit.o
 %if %{build_libubsan}
 ln -sf ../../../../%{_lib}/libubsan.so.1.* libubsan.so
 %endif
+%if %{build_go}
+ln -sf ../../../../%{_lib}/libgo.so.22.* libgo.so
+%endif
 %if %{build_libtsan}
 rm -f libtsan.so
 echo 'INPUT ( %{_prefix}/%{_lib}/'`echo ../../../../%{_lib}/libtsan.so.2.* | sed 's,^.*libt,libt,'`' )' > libtsan.so
@@ -1084,6 +1144,11 @@ ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libs
 %if %{build_libquadmath}
 ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libquadmath.a 32/libquadmath.a
 %endif
+%if %{build_go}
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgo.a 32/libgo.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgobegin.a 32/libgobegin.a
+ln -sf ../../../%{multilib_32_arch}-%{_vendor}-%{_target_os}/%{gcc_version}/libgolibbegin.a 32/libgolibbegin.a
+%endif
 %endif
 
 # If we are building a debug package then copy all of the static archives
@@ -1109,9 +1174,9 @@ for d in . $FULLLSUBDIR; do
 done
 %endif
 
-# Strip debug info from Fortran/ObjC/Java static libraries
+# Strip debug info from Fortran/ObjC/Java/Go static libraries
 strip -g `find . \( -name libobjc.a -o -name libgomp.a \
-		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \) -a -type f`
+		    -o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a -o -name libgo.a \) -a -type f`
 popd
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgomp.so.1.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
@@ -1139,16 +1204,6 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libtsan.so.2.*
 %endif
 %if %{build_liblsan}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/liblsan.so.0.*
-%endif
-%if %{build_go}
-# Avoid stripping these libraries and binaries.
-chmod 644 %{buildroot}%{_prefix}/%{_lib}/libgo.so.22.*
-chmod 644 %{buildroot}%{_prefix}/bin/go.gcc
-chmod 644 %{buildroot}%{_prefix}/bin/gofmt.gcc
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
-chmod 644 %{buildroot}%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
 %endif
 %if %{build_objc}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libobjc.so.4.*
@@ -1338,6 +1393,26 @@ if posix.access ("/sbin/ldconfig", "x") then
     posix.wait (pid)
   end
 end
+
+%post go
+pushd %{_bindir}
+if [ ! -f go ] ; then
+  ln -s go.gcc go
+fi
+if [ ! -f gofmt ] ; then
+  ln -s gofmt.gcc gofmt
+fi
+popd
+
+%preun go
+pushd %{_bindir}
+if [ -L go ]; then
+  rm go
+fi
+if [ -L gofmt ]; then
+  rm gofmt
+fi
+popd
 
 %post -n libstdc++ -p /sbin/ldconfig
 
@@ -1941,6 +2016,72 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/liblsan.a
 %{!?_licensedir:%global license %%doc}
 %license libsanitizer/LICENSE.TXT
+%endif
+
+%if %{build_go}
+%files go
+%ghost %{_prefix}/bin/go
+%attr(755,root,root) %{_prefix}/bin/go.gcc
+%{_prefix}/bin/gccgo
+%ghost %{_prefix}/bin/gofmt
+%attr(755,root,root) %{_prefix}/bin/gofmt.gcc
+%{_mandir}/man1/gccgo.1*
+%{_mandir}/man1/go.1*
+%{_mandir}/man1/gofmt.1*
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/libexec/gcc
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}
+%dir %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}
+%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/go1
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/cgo
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/buildid
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/test2json
+%attr(755,root,root) %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/vet
+%ifarch %{multilib_64_archs}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.so
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgo.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/32/libgolibbegin.a
+%endif
+%ifarch sparcv9 ppc %{multilib_64_archs}
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+%doc rpm.doc/go/*
+
+%files -n libgo
+%attr(755,root,root) %{_prefix}/%{_lib}/libgo.so.22*
+%doc rpm.doc/libgo/*
+
+%files -n libgo-devel
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%ifarch %{multilib_64_archs}
+%ifnarch sparc64 ppc64 ppc64p7
+%dir %{_prefix}/%{_lib}/go
+%dir %{_prefix}/%{_lib}/go/%{gcc_version}
+%{_prefix}/%{_lib}/go/%{gcc_version}/%{gcc_target_platform}
+%endif
+%endif
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgobegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgolibbegin.a
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.so
+%endif
+
+%files -n libgo-static
+%dir %{_prefix}/%{_lib}/gcc
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
+%dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}
+%ifnarch sparcv9 sparc64 ppc ppc64 ppc64p7
+%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/libgo.a
+%endif
 %endif
 
 %files plugin-devel

--- a/rpm/gcc.spec
+++ b/rpm/gcc.spec
@@ -245,14 +245,15 @@ Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man and info pages for %{name}.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgcc
 Summary: GCC version 13.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc
@@ -312,7 +313,8 @@ Autoreq: true
 %description -n libstdc++-doc
 Manual, doxygen generated API information and Frequently Asked Questions
 for the GNU standard C++ library.
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %package -n libgomp
 Summary: GCC OpenMP v4.5 shared support library
@@ -1278,7 +1280,8 @@ set +x
 #install -m0644 -t %{buildroot}%{_docdir}/libquadmath-%{version} \
 #        rpm.doc/libquadmath/ChangeLog*
 #%endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %if !%{crossbuild}
 # checking and split packaging for native ...
@@ -1385,11 +1388,11 @@ end
 %{_prefix}/bin/gcc-nm
 %{_prefix}/bin/gcc-ranlib
 %{_prefix}/bin/lto-dump
-#%ifnarch %{arm} aarch64 mipsel
-#%{_prefix}/bin/%{gcc_target_platform}-gcc
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ar
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-nm
-#%{_prefix}/bin/%{gcc_target_platform}-gcc-ranlib
+#%ifnarch %%{arm} aarch64 mipsel
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ar
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-nm
+#%%{_prefix}/bin/%%{gcc_target_platform}-gcc-ranlib
 #%endif
 %dir %{_prefix}/%{_lib}/gcc
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}
@@ -1400,8 +1403,8 @@ end
 %dir %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/*
-#%if !%{crossbuild}
+#%%{_prefix}/libexec/gcc/%%{gcc_target_platform}/%%{gcc_version}/*
+#%if !%%{crossbuild}
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto1
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/lto-wrapper
 %{_prefix}/libexec/gcc/%{gcc_target_platform}/%{gcc_version}/liblto_plugin.so*
@@ -1414,7 +1417,7 @@ end
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/plugin/include/*
 
 # Shouldn't include all files under this fold, split to diff pkgs
-#%{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/*
+#%%{_prefix}/%%{_lib}/gcc/%%{gcc_target_platform}/%%{gcc_version}/include/*
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/rpmver
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stddef.h
 %{_prefix}/%{_lib}/gcc/%{gcc_target_platform}/%{gcc_version}/include/stdarg.h
@@ -1708,7 +1711,8 @@ end
 %{_mandir}/man1/g++.1*
 %{_mandir}/man1/lto-dump.1*
 %{_mandir}/man7/*
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n cpp -f cpplib.lang
 %defattr(-,root,root,-)
@@ -1798,7 +1802,8 @@ end
 %{_mandir}/man3/*
 %{_docdir}/libstdc++-%{version}
 %endif
-%endif # !crossbuild
+# !crossbuild
+%endif
 
 %files -n libgomp
 %defattr(-,root,root,-)

--- a/rpm/gcc.spec
+++ b/rpm/gcc.spec
@@ -1119,8 +1119,8 @@ chmod 755 %{buildroot}%{_prefix}/%{_lib}/libcc1.so.0.*
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libquadmath.so.0.*
 %endif
 %if %{build_d}
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.1.*
-chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.1.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgdruntime.so.4.*
+chmod 755 %{buildroot}%{_prefix}/%{_lib}/libgphobos.so.4.*
 %endif
 %if %{build_libitm}
 chmod 755 %{buildroot}%{_prefix}/%{_lib}/libitm.so.1.*


### PR DESCRIPTION
Note: GCC 13

GCC 13 `gccgo` fully implements [Go 1.18](https://go.dev/doc/install/gccgo) standard library. This builds Go 1.21 which builds Go 1.23 - i.e. the latest version at the time of writing.

This PR is basically a carbon copy of #7 with some more cleanup.

- Restore missing pieces in .spec file
- Enable `gcc-go` with `build_go 1`
- Fix a few things here and there

This branch is able to compile Go 1.21 successfully.