### PR TITLE
Fix update order regarding glibc. JB#63419

### DIFF
--- a/cross-aarch64-gcc.spec
+++ b/cross-aarch64-gcc.spec
@@ -253,7 +253,7 @@ Man and info pages for %{name}.
 %package -n libgcc
 Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
-Autoreq: false
+Autoreq: true
 %if "%{version}" != "%{gcc_version}"
 Provides: libgcc = %{gcc_provides}
 %endif

--- a/cross-aarch64-gcc.spec
+++ b/cross-aarch64-gcc.spec
@@ -255,7 +255,7 @@ Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc

--- a/cross-aarch64-gcc.spec
+++ b/cross-aarch64-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %endif
 
 %global gcc_version 10.3.1
-%global gcc_release 2
+%global gcc_release 3
 %global _unpackaged_files_terminate_build 0
 %global _performance_build 1
 %global build_ada 0

--- a/cross-armv7hl-gcc.spec
+++ b/cross-armv7hl-gcc.spec
@@ -253,7 +253,7 @@ Man and info pages for %{name}.
 %package -n libgcc
 Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
-Autoreq: false
+Autoreq: true
 %if "%{version}" != "%{gcc_version}"
 Provides: libgcc = %{gcc_provides}
 %endif

--- a/cross-armv7hl-gcc.spec
+++ b/cross-armv7hl-gcc.spec
@@ -255,7 +255,7 @@ Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc

--- a/cross-armv7hl-gcc.spec
+++ b/cross-armv7hl-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %endif
 
 %global gcc_version 10.3.1
-%global gcc_release 2
+%global gcc_release 3
 %global _unpackaged_files_terminate_build 0
 %global _performance_build 1
 %global build_ada 0

--- a/cross-i486-gcc.spec
+++ b/cross-i486-gcc.spec
@@ -253,7 +253,7 @@ Man and info pages for %{name}.
 %package -n libgcc
 Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
-Autoreq: false
+Autoreq: true
 %if "%{version}" != "%{gcc_version}"
 Provides: libgcc = %{gcc_provides}
 %endif

--- a/cross-i486-gcc.spec
+++ b/cross-i486-gcc.spec
@@ -255,7 +255,7 @@ Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc

--- a/cross-i486-gcc.spec
+++ b/cross-i486-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %endif
 
 %global gcc_version 10.3.1
-%global gcc_release 2
+%global gcc_release 3
 %global _unpackaged_files_terminate_build 0
 %global _performance_build 1
 %global build_ada 0

--- a/cross-x86_64-gcc.spec
+++ b/cross-x86_64-gcc.spec
@@ -253,7 +253,7 @@ Man and info pages for %{name}.
 %package -n libgcc
 Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
-Autoreq: false
+Autoreq: true
 %if "%{version}" != "%{gcc_version}"
 Provides: libgcc = %{gcc_provides}
 %endif

--- a/cross-x86_64-gcc.spec
+++ b/cross-x86_64-gcc.spec
@@ -255,7 +255,7 @@ Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc

--- a/cross-x86_64-gcc.spec
+++ b/cross-x86_64-gcc.spec
@@ -107,7 +107,7 @@ ExclusiveArch: %ix86 x86_64
 %endif
 
 %global gcc_version 10.3.1
-%global gcc_release 2
+%global gcc_release 3
 %global _unpackaged_files_terminate_build 0
 %global _performance_build 1
 %global build_ada 0

--- a/gcc.changes
+++ b/gcc.changes
@@ -1,3 +1,6 @@
+* Thu Jul 10 2025 Pami Ketolainen <pami.ketolainen@jolla.com> - 10.3.1-3
+- Fix update order regarding glibc. JB#63419
+
 * Mon Mar 17 2025 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 10.3.1-2
 - Disable debug packages for cross packages. JB#63163
 - Disable AutoReq for libgcc. JB#49501

--- a/gcc.spec
+++ b/gcc.spec
@@ -254,7 +254,7 @@ Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
 Autoreq: true
 %if "%{version}" != "%{gcc_version}"
-Provides: libgcc = %{gcc_provides}
+Provides: libgcc = %{gcc_version}
 %endif
 
 %description -n libgcc

--- a/gcc.spec
+++ b/gcc.spec
@@ -106,7 +106,7 @@ ExclusiveArch: %ix86 x86_64
 %endif
 
 %global gcc_version 10.3.1
-%global gcc_release 2
+%global gcc_release 3
 %global _unpackaged_files_terminate_build 0
 %global _performance_build 1
 %global build_ada 0

--- a/gcc.spec
+++ b/gcc.spec
@@ -252,7 +252,7 @@ Man and info pages for %{name}.
 %package -n libgcc
 Summary: GCC version 10.3 shared support library
 Obsoletes: libgcc < %{version}-%{release}
-Autoreq: false
+Autoreq: true
 %if "%{version}" != "%{gcc_version}"
 Provides: libgcc = %{gcc_provides}
 %endif


### PR DESCRIPTION
Installing libgcc built agains new glibc before new glibc breaks at least on 32bit arm due to some unwind related symbol dependencies.

Autoreq ensure libgcc has the correct Requires on glibc and the packages are updated in correct order.

Related PR on glibc: https://github.com/sailfishos/glibc/pull/9