### PR TITLE
Backport changes needed for glibc 2.42 and newer

### DIFF
--- a/rpm/cross-aarch64-gcc.spec
+++ b/rpm/cross-aarch64-gcc.spec
@@ -175,6 +175,8 @@ Patch10: gcc13-rh1574936.patch
 Patch11: gcc13-d-shared-libphobos.patch
 Patch12: gcc13-reproducible-builds.patch
 Patch13: gcc13-reproducible-builds-buildid-for-checksum.patch
+Patch14: gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+Patch15: gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
 Patch50: isl-rh2155127.patch
 Patch100: gcc13-fortran-fdec-duplicates.patch
 

--- a/rpm/cross-armv7hl-gcc.spec
+++ b/rpm/cross-armv7hl-gcc.spec
@@ -175,6 +175,8 @@ Patch10: gcc13-rh1574936.patch
 Patch11: gcc13-d-shared-libphobos.patch
 Patch12: gcc13-reproducible-builds.patch
 Patch13: gcc13-reproducible-builds-buildid-for-checksum.patch
+Patch14: gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+Patch15: gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
 Patch50: isl-rh2155127.patch
 Patch100: gcc13-fortran-fdec-duplicates.patch
 

--- a/rpm/cross-i486-gcc.spec
+++ b/rpm/cross-i486-gcc.spec
@@ -175,6 +175,8 @@ Patch10: gcc13-rh1574936.patch
 Patch11: gcc13-d-shared-libphobos.patch
 Patch12: gcc13-reproducible-builds.patch
 Patch13: gcc13-reproducible-builds-buildid-for-checksum.patch
+Patch14: gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+Patch15: gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
 Patch50: isl-rh2155127.patch
 Patch100: gcc13-fortran-fdec-duplicates.patch
 

--- a/rpm/cross-x86_64-gcc.spec
+++ b/rpm/cross-x86_64-gcc.spec
@@ -175,6 +175,8 @@ Patch10: gcc13-rh1574936.patch
 Patch11: gcc13-d-shared-libphobos.patch
 Patch12: gcc13-reproducible-builds.patch
 Patch13: gcc13-reproducible-builds-buildid-for-checksum.patch
+Patch14: gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+Patch15: gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
 Patch50: isl-rh2155127.patch
 Patch100: gcc13-fortran-fdec-duplicates.patch
 

--- a/rpm/gcc.spec
+++ b/rpm/gcc.spec
@@ -174,6 +174,8 @@ Patch10: gcc13-rh1574936.patch
 Patch11: gcc13-d-shared-libphobos.patch
 Patch12: gcc13-reproducible-builds.patch
 Patch13: gcc13-reproducible-builds-buildid-for-checksum.patch
+Patch14: gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+Patch15: gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
 Patch50: isl-rh2155127.patch
 Patch100: gcc13-fortran-fdec-duplicates.patch
 

--- a/rpm/gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
+++ b/rpm/gcc13-backport-libsanitizer-Fix-build-with-glibc-2.42.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 2 May 2025 17:41:43 +0200
+Subject: [PATCH] libsanitizer: Fix build with glibc 2.42
+
+The termio structure will be removed from glibc 2.42.  It has
+been deprecated since the late 80s/early 90s.
+
+Cherry-picked from LLVM commit 59978b21ad9c65276ee8e14f26759691b8a65763
+("[sanitizer_common] Remove interceptors for deprecated struct termio
+(#137403)").
+
+Co-Authored-By: Tom Stellard <tstellar@redhat.com>
+
+libsanitizer/
+
+	* sanitizer_common/sanitizer_common_interceptors_ioctl.inc: Cherry
+	picked from LLVM commit 59978b21ad9c65276ee8e14f26759691b8a65763.
+	* sanitizer_common/sanitizer_platform_limits_posix.cpp: Likewise.
+	* sanitizer_common/sanitizer_platform_limits_posix.h: Likewise.
+
+(cherry picked from commit 1789c57dc97ea2f9819ef89e28bf17208b6208e7)
+---
+ .../sanitizer_common_interceptors_ioctl.inc               | 8 --------
+ .../sanitizer_common/sanitizer_platform_limits_posix.cpp  | 3 ---
+ .../sanitizer_common/sanitizer_platform_limits_posix.h    | 1 -
+ 3 files changed, 12 deletions(-)
+
+diff --git libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 49ec4097c900bd7fd23efaa7ac3bf32438d67ee8..dda11daa77f4974cb3767aa5ee95352bdb1c6b1b 100644
+--- libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -338,17 +338,9 @@ static void ioctl_table_fill() {
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCGETA, WRITE, struct_termio_sz);
+-#endif
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+-#endif
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+diff --git libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index c85cf1626a75b1b0d43fc6f3026e3b87fb6bcb15..c13811e39a4478e5da953bf5dc12881fd7676b2f 100644
+--- libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -467,9 +467,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-#if SANITIZER_GLIBC || SANITIZER_ANDROID
+-  unsigned struct_termio_sz = sizeof(struct termio);
+-#endif
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+diff --git libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index 44dd3d9e22d1c6e748b1af4c6aaac865e8d45ed9..45c1e1302f8f2f9acafc7fdc4f7b38d56a66e2a7 100644
+--- libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -998,7 +998,6 @@ extern unsigned struct_hd_geometry_sz;
+ extern unsigned struct_input_absinfo_sz;
+ extern unsigned struct_input_id_sz;
+ extern unsigned struct_mtpos_sz;
+-extern unsigned struct_termio_sz;
+ extern unsigned struct_vt_consize_sz;
+ extern unsigned struct_vt_sizes_sz;
+ extern unsigned struct_vt_stat_sz;

--- a/rpm/gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
+++ b/rpm/gcc13-backport-sanitizer_common-Remove-reference-to-obsolete-termio.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 25 Jul 2025 19:45:18 +0100
+Subject: [PATCH] [sanitizer_common] Remove reference to obsolete termio ioctls
+ (#138822)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Cherry picked from LLVM commit c99b1bcd505064f2e086e6b1034ce0b0c91ea5b9.
+
+The termio ioctls are no longer used after commit 59978b21ad9c
+("[sanitizer_common] Remove interceptors for deprecated struct termio
+(#137403)"), remove them.  Fixes this build error:
+
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:765:27: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  765 |   unsigned IOCTL_TCGETA = TCGETA;
+      |                           ^~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:769:27: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  769 |   unsigned IOCTL_TCSETA = TCSETA;
+      |                           ^~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:770:28: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  770 |   unsigned IOCTL_TCSETAF = TCSETAF;
+      |                            ^~~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:771:28: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  771 |   unsigned IOCTL_TCSETAW = TCSETAW;
+      |                            ^~~~~~~
+
+(cherry picked from commit dbe0ba6c90d53229613c7eb3f476580ae1b9aae1)
+---
+ .../sanitizer_common/sanitizer_platform_limits_posix.cpp      | 4 ----
+ .../sanitizer_common/sanitizer_platform_limits_posix.h        | 4 ----
+ 2 files changed, 8 deletions(-)
+
+diff --git libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index c13811e39a4478e5da953bf5dc12881fd7676b2f..cb50a272c42226edf61466df523232d55d50d5bd 100644
+--- libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -743,13 +743,9 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_SOUND_PCM_WRITE_FILTER = SOUND_PCM_WRITE_FILTER;
+ #endif // SOUND_VERSION
+   unsigned IOCTL_TCFLSH = TCFLSH;
+-  unsigned IOCTL_TCGETA = TCGETA;
+   unsigned IOCTL_TCGETS = TCGETS;
+   unsigned IOCTL_TCSBRK = TCSBRK;
+   unsigned IOCTL_TCSBRKP = TCSBRKP;
+-  unsigned IOCTL_TCSETA = TCSETA;
+-  unsigned IOCTL_TCSETAF = TCSETAF;
+-  unsigned IOCTL_TCSETAW = TCSETAW;
+   unsigned IOCTL_TCSETS = TCSETS;
+   unsigned IOCTL_TCSETSF = TCSETSF;
+   unsigned IOCTL_TCSETSW = TCSETSW;
+diff --git libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index 45c1e1302f8f2f9acafc7fdc4f7b38d56a66e2a7..70ea7e3c1bc235b32c6a4b6737d83019809bfb7e 100644
+--- libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1242,13 +1242,9 @@ extern unsigned IOCTL_SNDCTL_COPR_SENDMSG;
+ extern unsigned IOCTL_SNDCTL_COPR_WCODE;
+ extern unsigned IOCTL_SNDCTL_COPR_WDATA;
+ extern unsigned IOCTL_TCFLSH;
+-extern unsigned IOCTL_TCGETA;
+ extern unsigned IOCTL_TCGETS;
+ extern unsigned IOCTL_TCSBRK;
+ extern unsigned IOCTL_TCSBRKP;
+-extern unsigned IOCTL_TCSETA;
+-extern unsigned IOCTL_TCSETAF;
+-extern unsigned IOCTL_TCSETAW;
+ extern unsigned IOCTL_TCSETS;
+ extern unsigned IOCTL_TCSETSF;
+ extern unsigned IOCTL_TCSETSW;


### PR DESCRIPTION
Patches remove obsolete code which breaks builds with glib 2.42 and newer.